### PR TITLE
Add cjs and js-ts-mode in lsp-javascript

### DIFF
--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -50,7 +50,7 @@
 
 (defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
   "Check if the js-ts lsp server should be enabled based on FILENAME."
-  (or (string-match-p "\\.mjs\\|\\.[jt]sx?\\'" filename)
+  (or (string-match-p "\\.[cm]js\\|\\.[jt]sx?\\'" filename)
       (and (derived-mode-p 'js-mode 'typescript-mode 'typescript-ts-mode)
            (not (derived-mode-p 'json-mode)))))
 

--- a/clients/lsp-javascript.el
+++ b/clients/lsp-javascript.el
@@ -51,7 +51,7 @@
 (defun lsp-typescript-javascript-tsx-jsx-activate-p (filename &optional _)
   "Check if the js-ts lsp server should be enabled based on FILENAME."
   (or (string-match-p "\\.[cm]js\\|\\.[jt]sx?\\'" filename)
-      (and (derived-mode-p 'js-mode 'typescript-mode 'typescript-ts-mode)
+      (and (derived-mode-p 'js-mode 'js-ts-mode 'typescript-mode 'typescript-ts-mode)
            (not (derived-mode-p 'json-mode)))))
 
 ;; Unmaintained sourcegraph server


### PR DESCRIPTION
Node.js supports the [.cjs](https://nodejs.org/api/modules.html#enabling) extension to treat a file as CommonJS module.

This PR will make lsp-mode activate the language server properly.
It also adds the `js-ts-mode` to the mode list, which is a tree-sitter mode in Emacs 29.